### PR TITLE
Precise event naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ YES:
 event OwnerUpdated(address newOwner);
 ```
 
-##### B. Prefer `SubjectVerb` naming format
+##### B. Prefer `SubjectVerb` naming format.
 
 NO:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For example, `InsufficientBalance`.
 
 For example, `OwnerUpdated` not `UpdateOwner`.
 
-Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions. We also recommend following the `WhatAction`(e.g. `OwnerUpdated`) format rather than `ActionWhat` (e.g. `UpdatedOwner`).
+Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions. We also recommend following the `SubjectVerb`(e.g. `OwnerUpdated`) format rather than `VerbSubject` (e.g. `UpdatedOwner`).
 
 We are aware this does not follow precedent from early ERCs, like [ERC-20](https://eips.ethereum.org/EIPS/eip-20). However it does align with some more recent high profile Solidity, e.g. [1](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/976a3d53624849ecaef1231019d2052a16a39ce4/contracts/access/Ownable.sol#L33), [2](https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/interfaces/IAaveOracle.sol#L25-L31), [3](https://github.com/ProjectOpenSea/seaport/blob/1d12e33b71b6988cbbe955373ddbc40a87bd5b16/contracts/zones/interfaces/PausableZoneEventsAndErrors.sol#L25-L41).
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,39 @@ Custom errors are in some cases more gas efficient and allow passing useful info
 
 For example, `InsufficientBalance`.
 
-#### 3. Event names should be past tense.
+#### 3. Events
 
-For example, `OwnerUpdated` not `UpdateOwner`.
+##### A. Events names should be past tense.
 
-Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions. We also recommend following the `SubjectVerb`(e.g. `OwnerUpdated`) format rather than `VerbSubject` (e.g. `UpdatedOwner`).
+Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions.
 
 We are aware this does not follow precedent from early ERCs, like [ERC-20](https://eips.ethereum.org/EIPS/eip-20). However it does align with some more recent high profile Solidity, e.g. [1](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/976a3d53624849ecaef1231019d2052a16a39ce4/contracts/access/Ownable.sol#L33), [2](https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/interfaces/IAaveOracle.sol#L25-L31), [3](https://github.com/ProjectOpenSea/seaport/blob/1d12e33b71b6988cbbe955373ddbc40a87bd5b16/contracts/zones/interfaces/PausableZoneEventsAndErrors.sol#L25-L41).
+
+NO:
+
+```solidity
+event OwnerUpdate(address newOwner);
+```
+
+YES:
+
+```solidity
+event OwnerUpdated(address newOwner);
+```
+
+##### B. Prefer `SubjectVerb` naming format
+
+NO:
+
+```solidity
+event UpdatedOwner(address newOwner);
+```
+
+YES:
+
+```solidity
+event OwnerUpdated(address newOwner);
+```
 
 #### 4. Avoid using assembly.
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ For example, `InsufficientBalance`.
 
 #### 3. Event names should be past tense.
 
-For example, `UpdatedOwner` not `UpdateOwner`.
+For example, `OwnerUpdated` not `UpdateOwner`.
 
-Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions.
+Events should track things that _happened_ and so should be past tense. Using past tense also helps avoid naming collisions with structs or functions. We also recommend following the `WhatAction`(e.g. `OwnerUpdated`) format rather than `ActionWhat` (e.g. `UpdatedOwner`).
 
 We are aware this does not follow precedent from early ERCs, like [ERC-20](https://eips.ethereum.org/EIPS/eip-20). However it does align with some more recent high profile Solidity, e.g. [1](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/976a3d53624849ecaef1231019d2052a16a39ce4/contracts/access/Ownable.sol#L33), [2](https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/interfaces/IAaveOracle.sol#L25-L31), [3](https://github.com/ProjectOpenSea/seaport/blob/1d12e33b71b6988cbbe955373ddbc40a87bd5b16/contracts/zones/interfaces/PausableZoneEventsAndErrors.sol#L25-L41).
 


### PR DESCRIPTION
In addition to recommending the usage of past tense for events naming, this PR further advise to follow a `WhatAction`(e.g. `OwnerUpdated`) format rather than `ActionWhat` (e.g. `UpdatedOwner`).