### PR TITLE
Add security contact NatSpec guideline to style guide

### DIFF
--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -452,10 +452,10 @@ Seguido opcionalmente por um link para o repositório público no Github.
 
 #### 5. Inclua um contato de segurança.
 
-Inclua a tag `@custom:security-contact` no NatSpec de nível superior do contrato. Esta tag NatSpec personalizada (reconhecida pelo Etherscan e outras ferramentas de verificação) informa aos usuários e auditores onde relatar vulnerabilidades de segurança.
+Inclua a tag `@custom:security-contact` no NatSpec de nível superior do contrato. Esta tag NatSpec personalizada (reconhecida pelo Etherscan e outras ferramentas de verificação) informa aos usuários e auditores onde relatar vulnerabilidades de segurança. Para contratos da Coinbase, use `security@coinbase.com`.
 
 ```solidity
-/// @custom:security-contact security@example.com
+/// @custom:security-contact security@coinbase.com
 contract MyContract {
   ...
 }

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -449,3 +449,14 @@ Se você estiver usando a tag `@author`, ela deve ser
 ```
 
 Seguido opcionalmente por um link para o repositório público no Github.
+
+#### 5. Inclua um contato de segurança.
+
+Inclua a tag `@custom:security-contact` no NatSpec de nível superior do contrato. Esta tag NatSpec personalizada (reconhecida pelo Etherscan e outras ferramentas de verificação) informa aos usuários e auditores onde relatar vulnerabilidades de segurança.
+
+```solidity
+/// @custom:security-contact security@example.com
+contract MyContract {
+  ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -493,3 +493,14 @@ If you using the `@author` tag, it should be
 ```
 
 Optionally followed by a link to the public Github repository.
+
+#### 5. Include a security contact.
+
+Include the `@custom:security-contact` tag in the contract's top-level NatSpec. This custom NatSpec tag (recognized by Etherscan and other verification tools) tells users and auditors where to report security vulnerabilities.
+
+```solidity
+/// @custom:security-contact security@example.com
+contract MyContract {
+  ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -496,10 +496,10 @@ Optionally followed by a link to the public Github repository.
 
 #### 5. Include a security contact.
 
-Include the `@custom:security-contact` tag in the contract's top-level NatSpec. This custom NatSpec tag (recognized by Etherscan and other verification tools) tells users and auditors where to report security vulnerabilities.
+Include the `@custom:security-contact` tag in the contract's top-level NatSpec. This custom NatSpec tag (recognized by Etherscan and other verification tools) tells users and auditors where to report security vulnerabilities. For Coinbase contracts, use `security@coinbase.com`.
 
 ```solidity
-/// @custom:security-contact security@example.com
+/// @custom:security-contact security@coinbase.com
 contract MyContract {
   ...
 }


### PR DESCRIPTION
Adds a new NatSpec guideline recommending the use of the `@custom:security-contact` tag in contract-level documentation.

This custom NatSpec tag is recognized by Etherscan and other verification tools, providing users and auditors with a clear channel for reporting security vulnerabilities.

Updates both English and Portuguese versions of the style guide. Portuguese translation generated with AI assistance and verified via Google Translate.